### PR TITLE
feat: change bg to plain white

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -33,8 +33,8 @@ body {
 
  background-attachment: fixed;
     background-clip: border-box;
-    background-color: #14181B;
-    background-image: url("../images/neuron_black_gs.jpg");
+    background-color: #ffffff;
+    /*background-image: url("../images/neuron_black_gs.jpg");*/
     background-origin: padding-box;
     background-position: center top;
     background-repeat: no-repeat;
@@ -69,7 +69,7 @@ top: 85px;
 left: 145px;
 left: 5;
 font-style: italic;
-color: #dadada;
+color: #111111;
 font-size: 14px;
 }
 #main{


### PR DESCRIPTION
Also darkens the top header text to make it visible.

I couldn't get the webapp to work here. Even with `rubyenv` etc., I can't install an older version of ruby---compilation segfaults :roll_eyes: , but this what it'll look like (by changing bits in the devtools):

![neuroml-web-white](https://user-images.githubusercontent.com/102575/148231957-92a1d552-0549-4028-a786-813ccf212183.png)
